### PR TITLE
build(deps): bump uuid from 11.1.0 to 14.0.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,12 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@coursetable/passport-cas",
       "dependencies": {
         "passport-strategy": "^1.0.0",
-        "uuid": "^11.0.5",
+        "uuid": "^14.0.0",
         "xml2js": "^0.6.2",
       },
       "devDependencies": {
@@ -14,7 +15,6 @@
         "@types/node": "^20.11.0",
         "@types/passport": "^1.0.16",
         "@types/passport-strategy": "^0.2.38",
-        "@types/uuid": "^9.0.7",
         "@types/verror": "^1.10.9",
         "@types/xml2js": "^0.4.14",
         "body-parser": "^1.20.2",
@@ -74,8 +74,6 @@
     "@types/send": ["@types/send@0.17.4", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA=="],
 
     "@types/serve-static": ["@types/serve-static@1.15.7", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "*" } }, "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw=="],
-
-    "@types/uuid": ["@types/uuid@9.0.8", "", {}, "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="],
 
     "@types/verror": ["@types/verror@1.10.11", "", {}, "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg=="],
 
@@ -253,7 +251,7 @@
 
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
 
-    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+    "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
     "v8-compile-cache-lib": ["v8-compile-cache-lib@3.0.1", "", {}, "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/coursetable/passport-cas",
   "dependencies": {
     "passport-strategy": "^1.0.0",
-    "uuid": "^11.0.5",
+    "uuid": "^14.0.0",
     "xml2js": "^0.6.2"
   },
   "devDependencies": {
@@ -35,7 +35,6 @@
     "@types/node": "^20.11.0",
     "@types/passport": "^1.0.16",
     "@types/passport-strategy": "^0.2.38",
-    "@types/uuid": "^9.0.7",
     "@types/verror": "^1.10.9",
     "@types/xml2js": "^0.4.14",
     "body-parser": "^1.20.2",


### PR DESCRIPTION
fix https://github.com/uuidjs/uuid/security/advisories/GHSA-w5hq-g745-h8pq

Also remove @types/uuid devDependencies because "uuid provides its own type definitions, so you do not need this installed" (cf https://www.npmjs.com/package/@types/uuid )